### PR TITLE
Add ArgoCD notifications

### DIFF
--- a/apps/infra-argo-cd.yaml
+++ b/apps/infra-argo-cd.yaml
@@ -21,14 +21,14 @@ spec:
             admin.enabled: false
             dex.config: |
               connectors:
-              - type: github
-                id: github
-                name: GitHub
-                config:
-                  clientID: 36bc63e3739b7724c29a
-                  clientSecret: $github-oauth:dex.github.clientSecret
-                  orgs:
-                  - name: bacchus-snu
+                - type: github
+                  id: github
+                  name: GitHub
+                  config:
+                    clientID: 36bc63e3739b7724c29a
+                    clientSecret: $github-oauth:dex.github.clientSecret
+                    orgs:
+                      - name: bacchus-snu
             url: https://cd.bacchus.io
           params:
             server.insecure: true
@@ -39,12 +39,321 @@ spec:
         server:
           ingress:
             enabled: true
-            hosts:
-            - cd.bacchus.io
             ingressClassName: nginx
+            hosts:
+              - cd.bacchus.io
+        notifications:
+          argocdUrl: 'https://cd.bacchus.io'
+          secret:
+            create: false
+          notifiers:
+            service.webhook.slack-webhook: |
+              url: $slack-webhook
+              headers:
+                - name: Content-Type
+                  value: application/json
+          subscriptions:
+            - recipients:
+                - slack-webhook
+              triggers:
+                - on-deployed
+                - on-health-degraded
+                - on-sync-failed
+          templates:
+            template.app-created: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": "Application {{.app.metadata.name}} has been created."
+                    }
+            template.app-deleted: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": "Application {{.app.metadata.name}} has been deleted."
+                    }
+            template.app-deployed: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": ":white_check_mark: Application {{.app.metadata.name}} is now running new version of deployments manifests.",
+                      "attachments": [{
+                        "title": "{{ .app.metadata.name}}",
+                        "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+                        "color": "#18be52",
+                        "fields": [
+                        {
+                          "title": "Sync Status",
+                          "value": "{{.app.status.sync.status}}",
+                          "short": true
+                        },
+                        {
+                          "title": "Repository",
+                          "value": "{{.app.spec.source.repoURL}}",
+                          "short": true
+                        },
+                        {
+                          "title": "Revision",
+                          "value": "{{.app.status.sync.revision}}",
+                          "short": true
+                        }
+                        {{range $index, $c := .app.status.conditions}}
+                        {{if not $index}},{{end}}
+                        {{if $index}},{{end}}
+                        {
+                          "title": "{{$c.type}}",
+                          "value": "{{$c.message}}",
+                          "short": true
+                        }
+                        {{end}}
+                        ]
+                      }]
+                    }
+            template.app-health-degraded: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": ":exclamation: Application {{.app.metadata.name}} has degraded.\nApplication details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.",
+                      "attachments": [{
+                        "title": "{{ .app.metadata.name}}",
+                        "title_link": "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+                        "color": "#f4c030",
+                        "fields": [
+                        {
+                          "title": "Health Status",
+                          "value": "{{.app.status.health.status}}",
+                          "short": true
+                        },
+                        {
+                          "title": "Repository",
+                          "value": "{{.app.spec.source.repoURL}}",
+                          "short": true
+                        }
+                        {{range $index, $c := .app.status.conditions}}
+                        {{if not $index}},{{end}}
+                        {{if $index}},{{end}}
+                        {
+                          "title": "{{$c.type}}",
+                          "value": "{{$c.message}}",
+                          "short": true
+                        }
+                        {{end}}
+                        ]
+                      }]
+                    }
+            template.app-sync-failed: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": ":exclamation: The sync operation of application {{.app.metadata.name}} has failed at {{.app.status.operationState.finishedAt}} with the following error: {{.app.status.operationState.message}}\nSync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .",
+                      "attachments": [{
+                        "title": "{{ .app.metadata.name}}",
+                        "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+                        "color": "#E96D76",
+                        "fields": [
+                        {
+                          "title": "Sync Status",
+                          "value": "{{.app.status.sync.status}}",
+                          "short": true
+                        },
+                        {
+                          "title": "Repository",
+                          "value": "{{.app.spec.source.repoURL}}",
+                          "short": true
+                        }
+                        {{range $index, $c := .app.status.conditions}}
+                        {{if not $index}},{{end}}
+                        {{if $index}},{{end}}
+                        {
+                          "title": "{{$c.type}}",
+                          "value": "{{$c.message}}",
+                          "short": true
+                        }
+                        {{end}}
+                        ]
+                      }]
+                    }
+            template.app-sync-running: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": "The sync operation of application {{.app.metadata.name}} has started at {{.app.status.operationState.startedAt}}.\nSync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .",
+                      "attachments": [{
+                        "title": "{{ .app.metadata.name}}",
+                        "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+                        "color": "#0DADEA",
+                        "fields": [
+                        {
+                          "title": "Sync Status",
+                          "value": "{{.app.status.sync.status}}",
+                          "short": true
+                        },
+                        {
+                          "title": "Repository",
+                          "value": "{{.app.spec.source.repoURL}}",
+                          "short": true
+                        }
+                        {{range $index, $c := .app.status.conditions}}
+                        {{if not $index}},{{end}}
+                        {{if $index}},{{end}}
+                        {
+                          "title": "{{$c.type}}",
+                          "value": "{{$c.message}}",
+                          "short": true
+                        }
+                        {{end}}
+                        ]
+                      }]
+                    }
+            template.app-sync-status-unknown: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": ":exclamation: Application {{.app.metadata.name}} sync is 'Unknown'.\nApplication details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.",
+                      "attachments": [{
+                        "title": "{{ .app.metadata.name}}",
+                        "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+                        "color": "#E96D76",
+                        "fields": [
+                        {
+                          "title": "Sync Status",
+                          "value": "{{.app.status.sync.status}}",
+                          "short": true
+                        },
+                        {
+                          "title": "Repository",
+                          "value": "{{.app.spec.source.repoURL}}",
+                          "short": true
+                        }
+                        {{range $index, $c := .app.status.conditions}}
+                        {{if not $index}},{{end}}
+                        {{if $index}},{{end}}
+                        {
+                          "title": "{{$c.type}}",
+                          "value": "{{$c.message}}",
+                          "short": true
+                        }
+                        {{end}}
+                        ]
+                      }]
+                    }
+            template.app-sync-succeeded: |
+              webhook:
+                slack-webhook:
+                  method: POST
+                  body: |
+                    {
+                      "text": ":white_check_mark: Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.\nSync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .",
+                      "attachments": [{
+                        "title": "{{ .app.metadata.name}}",
+                        "title_link":"{{.context.argocdUrl}}/applications/{{.app.metadata.name}}",
+                        "color": "#18be52",
+                        "fields": [
+                        {
+                          "title": "Sync Status",
+                          "value": "{{.app.status.sync.status}}",
+                          "short": true
+                        },
+                        {
+                          "title": "Repository",
+                          "value": "{{.app.spec.source.repoURL}}",
+                          "short": true
+                        }
+                        {{range $index, $c := .app.status.conditions}}
+                        {{if not $index}},{{end}}
+                        {{if $index}},{{end}}
+                        {
+                          "title": "{{$c.type}}",
+                          "value": "{{$c.message}}",
+                          "short": true
+                        }
+                        {{end}}
+                        ]
+                      }]
+                    }
+          triggers:
+            trigger.on-created: |
+              - description: Application is created.
+                oncePer: app.metadata.name
+                send:
+                  - app-created
+                when: "true"
+            trigger.on-deleted: |
+              - description: Application is deleted.
+                oncePer: app.metadata.name
+                send:
+                  - app-deleted
+                when: app.metadata.deletionTimestamp != nil
+            trigger.on-deployed: |
+              - description: Application is synced and healthy. Triggered once per commit.
+                oncePer: app.status.operationState.syncResult.revision
+                send:
+                  - app-deployed
+                when: app.status.operationState.phase in ['Succeeded'] and app.status.health.status
+                  == 'Healthy'
+            trigger.on-health-degraded: |
+              - description: Application has degraded
+                send:
+                  - app-health-degraded
+                when: app.status.health.status == 'Degraded'
+            trigger.on-sync-failed: |
+              - description: Application syncing has failed
+                send:
+                  - app-sync-failed
+                when: app.status.operationState.phase in ['Error', 'Failed']
+            trigger.on-sync-running: |
+              - description: Application is being synced
+                send:
+                  - app-sync-running
+                when: app.status.operationState.phase in ['Running']
+            trigger.on-sync-status-unknown: |
+              - description: Application status is 'Unknown'
+                send:
+                  - app-sync-status-unknown
+                when: app.status.sync.status == 'Unknown'
+            trigger.on-sync-succeeded: |
+              - description: Application syncing has succeeded
+                send:
+                  - app-sync-succeeded
+                when: app.status.operationState.phase in ['Succeeded']
+            defaultTriggers: |
+              - on-deployed
+              - on-health-degraded
+              - on-sync-failed
   project: infra
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
       allowEmpty: false
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  namespace: argo
+  name: argocd-notifications-secret
+  labels:
+    app.kubernetes.io/part-of: argocd
+spec:
+  secretStoreRef:
+    name: cluster-secret-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: slack-webhook
+      remoteRef:
+        key: infra/argo/config
+        property: SLACK_WEBHOOK_URL


### PR DESCRIPTION
ArgoCD notification을 추가하여 디스코드 웹훅으로 메세지를 받아볼 수 있도록 작업합니다.

<여기에 스크린샷 입력>

다음 3가지 상황에 대해서는 기본적으로 메세지를 받도록 구성하였습니다.

* `on-deployed`
* `on-health-degraded`
* `on-sync-failed`

다음 문서들을 참고하였습니다.

* [Notification overview](https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/)
* [Send slack weboook](https://argo-cd.readthedocs.io/en/stable/operator-manual/notifications/services/webhook/#send-slack)
* [Triggers and template catalog](https://github.com/argoproj/argo-cd/blob/stable/notifications_catalog/install.yaml)
* [Helm chart values](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml#L2670-L3177)