### PR TITLE
feat: Replace to use paramter store

### DIFF
--- a/apps/bacchus-bridge/secret.yaml
+++ b/apps/bacchus-bridge/secret.yaml
@@ -11,9 +11,9 @@ spec:
   data:
     - secretKey: discord-token
       remoteRef:
-        key: infra/bacchus-bridge/config
+        key: /infra/bacchus-bridge/config
         property: discord-token
     - secretKey: slack-token
       remoteRef:
-        key: infra/bacchus-bridge/config
+        key: /infra/bacchus-bridge/config
         property: slack-token

--- a/apps/id-id-core.yaml
+++ b/apps/id-id-core.yaml
@@ -11,7 +11,7 @@ spec:
   data:
     - secretKey: 'config.json'
       remoteRef:
-        key: prod/id/config
+        key: /prod/id/config
         property: core
         decodingStrategy: Base64
 ---

--- a/apps/id-id-db.yaml
+++ b/apps/id-id-db.yaml
@@ -11,15 +11,15 @@ spec:
   data:
     - secretKey: db-password
       remoteRef:
-        key: prod/id/config
+        key: /prod/id/config
         property: db-password
     - secretKey: db-admin-password
       remoteRef:
-        key: prod/id/config
+        key: /prod/id/config
         property: db-admin-password
     - secretKey: db-replication-password
       remoteRef:
-        key: prod/id/config
+        key: /prod/id/config
         property: db-replication-password
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/apps/infra-external-secrets.yaml
+++ b/apps/infra-external-secrets.yaml
@@ -35,5 +35,5 @@ metadata:
 spec:
   provider:
     aws:
-      service: SecretsManager
+      service: ParameterStore
       region: ap-northeast-2

--- a/apps/infra-kube-prometheus-stack.yaml
+++ b/apps/infra-kube-prometheus-stack.yaml
@@ -329,5 +329,5 @@ spec:
   data:
     - secretKey: secret
       remoteRef:
-        key: infra/grafana/config
+        key: /infra/grafana/config
         property: GITHUB_OAUTH_CLIENT_SECRET

--- a/apps/infra-vaultwarden.yaml
+++ b/apps/infra-vaultwarden.yaml
@@ -107,7 +107,7 @@ spec:
   data:
     - secretKey: smtp-password
       remoteRef:
-        key: infra/vaultwarden/config
+        key: /infra/vaultwarden/config
         property: smtp-password
 ---
 apiVersion: v1


### PR DESCRIPTION
ClusterSecretStore가 SecretsManager가 아닌 ParameterStore를 사용하도록 교체합니다.

Parameter store에 모든 secret들이 마이그레이션 되어있어야 합니다.

이 리포에 없는 ExternalSecret은 손으로 만들어진 것들인걸까요?