### PR TITLE
feat(infra-dexidp): add bacchus-aws public client

### DIFF
--- a/apps/infra-dexidp.yaml
+++ b/apps/infra-dexidp.yaml
@@ -98,6 +98,9 @@ spec:
               redirectURIs:
                 - https://dashboard.bacchus.io/login/generic_oauth
               secretEnv: DEX_CLIENT_BACCHUS_GRAFANA
+            - name: AWS
+              id: bacchus-aws
+              public: true
 
           connectors:
             - name: Google


### PR DESCRIPTION
이건 바쿠스원이 실행하는 로컬 스크립트가 사용하는거니까 client secret을 넣기 어려우니 public client를 사용합니다