### PR TITLE
CSE 프로젝트 협업 목적의 브릿지 생성

### DIFF
--- a/apps/bacchus-bridge/configmap.yaml
+++ b/apps/bacchus-bridge/configmap.yaml
@@ -18,6 +18,10 @@ data:
         RemoteNickFormat = "@{NICK}"
         PreserveThreading = true
 
+        [slack.waffle]
+        RemoteNickFormat = "@{NICK}"
+        PreserveThreading = true
+
     [[gateway]]
         name = "random"
         enable = true
@@ -197,3 +201,16 @@ data:
         [[gateway.inout]]
         account = "slack.bacchus"
         channel = "project-escape-slack"
+
+    [[gateway]]
+        name = "cse-contact"
+        enable = true
+
+        [[gateway.inout]]
+        account = "discord.bacchus"
+        channel = "cse-contact"
+
+        [[gateway.inout]]
+        account = "slack.waffle"
+        channel = "team-cse-contact"
+

--- a/apps/bacchus-bridge/deployment.yaml
+++ b/apps/bacchus-bridge/deployment.yaml
@@ -29,6 +29,11 @@ spec:
                 secretKeyRef:
                   name: bacchus-bridge-config
                   key: slack-token
+            - name: MATTERBRIDGE_SLACK_WAFFLE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: bacchus-bridge-config
+                  key: slack-waffle-token
           resources:
             requests:
               cpu: 100m

--- a/apps/bacchus-bridge/secret.yaml
+++ b/apps/bacchus-bridge/secret.yaml
@@ -17,3 +17,7 @@ spec:
       remoteRef:
         key: /infra/bacchus-bridge/config
         property: slack-token
+    - secretKey: slack-token-waffle
+      remoteRef:
+        key: /infra/bacchus-bridge/config
+        property: slack-token-waffle

--- a/apps/bacchus-bridge/secret.yaml
+++ b/apps/bacchus-bridge/secret.yaml
@@ -17,7 +17,7 @@ spec:
       remoteRef:
         key: /infra/bacchus-bridge/config
         property: slack-token
-    - secretKey: slack-token-waffle
+    - secretKey: slack-waffle-token
       remoteRef:
         key: /infra/bacchus-bridge/config
-        property: slack-token-waffle
+        property: slack-waffle-token


### PR DESCRIPTION
바쿠스 디스코드 서버의 `cse-contact` 채널과 와플 스튜디오 슬랙 서버의 `team-cse-contact` 채널을 브릿지를 생성합니다.