### PR TITLE
feat: add dashboard using kube-prometheus-stack

### DIFF
--- a/foundation/argo/dashboard/app.yaml
+++ b/foundation/argo/dashboard/app.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  namespace: argocd
+  name: dashboard
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infra
+  destination:
+    name: in-cluster
+    namespace: dashboard
+  syncPolicy:
+  #   automated:
+  #     prune: true
+  #     selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  sources:
+    - repoURL: https://prometheus-community.github.io/helm-charts
+      targetRevision: 52.1.0
+      chart: kube-prometheus-stack
+      helm:
+        valueFiles:
+          - $values/foundation/argo/dashboard/values.yaml
+    - repoURL: https://github.com/bacchus-snu/cd-manifests.git
+      targetRevision: feat/talos
+      ref: values
+    - repoURL: https://github.com/bacchus-snu/cd-manifests.git
+      targetRevision: feat/talos
+      path: foundation/argo/dashboard
+      directory:
+        include: 'resources.yaml'

--- a/foundation/argo/dashboard/resources.yaml
+++ b/foundation/argo/dashboard/resources.yaml
@@ -41,5 +41,3 @@ spec:
   destination:
     create: true
     name: dex-auth
-    labels:
-      app.kubernetes.io/part-of: argocd

--- a/foundation/argo/dashboard/resources.yaml
+++ b/foundation/argo/dashboard/resources.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  namespace: dashboard
+  name: grafana
+spec:
+  parentRefs:
+    - namespace: cilium-system
+      name: web-gateway
+      sectionName: https-bacchus-io
+  hostnames:
+    - dashboard.bacchus.io
+  rules:
+    - backendRefs:
+        - name: dashboard-grafana
+          port: 80
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  namespace: dashboard
+  name: default
+spec:
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: vault-secrets-operator
+    serviceAccount: default
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  namespace: dashboard
+  name: dex-auth
+spec:
+  vaultAuthRef: default
+  type: kv-v2
+  mount: secret
+  path: dashboard/grafana/dex-auth
+  destination:
+    create: true
+    name: dex-auth
+    labels:
+      app.kubernetes.io/part-of: argocd

--- a/foundation/argo/dashboard/values.yaml
+++ b/foundation/argo/dashboard/values.yaml
@@ -1,0 +1,42 @@
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 100Gi
+
+grafana:
+  imageRenderer:
+    grafanaProtocol: https
+
+  grafana.ini:
+    server:
+      domain: dashboard.bacchus.io
+      root_url: "https://%(domain)s"
+
+    auth:
+      disable_login_form: true
+
+    auth.generic_oauth:
+      enabled: true
+      allow_sign_up: true
+      client_id: bacchus-grafana
+      client_secret: '$__file{/etc/secrets/dex-auth/secret}'
+      scopes: openid email profile groups
+      api_url: https://auth.bacchus.io/dex/userinfo
+      auth_url: https://auth.bacchus.io/dex/auth
+      token_url: https://auth.bacchus.io/dex/token
+      role_attribute_path: contains(groups[*], 'regular-members@bacchus.snucse.org') && 'Editor' || contains(groups[*], 'member@bacchus.snucse.org') && 'Viewer'
+
+    security:
+      disable_initial_admin_creation: true
+
+  extraSecretMounts:
+    - name: dex-auth
+      secretName: dex-auth
+      mountPath: /etc/secrets/dex-auth
+      readOnly: true


### PR DESCRIPTION
바쿠스 대시보드 : RE

### Changes

* `kube-prometheus-stack` 차트 설치
* httproute 및 dex client secret 설정
* Cloudflare DNS에 `dashboard.bacchus.io` 레코드 추가
* Grafana OAuth 설정
* Grafana 로그인 폼 비활성화 및 어드민 유저 생성하지 않도록 `grafana.ini`에 추가