### PR TITLE
feat: add external dns for httproute resources

### DIFF
--- a/foundation/argo/cilium/resources.yaml
+++ b/foundation/argo/cilium/resources.yaml
@@ -6,6 +6,7 @@ metadata:
   name: web-gateway
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    external-dns.alpha.kubernetes.io/target: waiter.bacchus.io
 spec:
   gatewayClassName: cilium
   listeners:

--- a/foundation/argo/external-dns/app.yaml
+++ b/foundation/argo/external-dns/app.yaml
@@ -27,3 +27,8 @@ spec:
     - repoURL: https://github.com/bacchus-snu/cd-manifests.git
       targetRevision: feat/talos
       ref: values
+    - repoURL: https://github.com/bacchus-snu/cd-manifests.git
+      targetRevision: feat/talos
+      path: foundation/argo/external-dns
+      directory:
+        include: 'resources.yaml'

--- a/foundation/argo/external-dns/app.yaml
+++ b/foundation/argo/external-dns/app.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  namespace: argocd
+  name: external-dns
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infra
+  destination:
+    name: in-cluster
+    namespace: external-dns
+  syncPolicy:
+  #   automated:
+  #     prune: true
+  #     selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+  sources:
+    - repoURL: https://kubernetes-sigs.github.io/external-dns/
+      targetRevision: 1.13.1
+      chart: external-dns
+      helm:
+        valueFiles:
+          - $values/foundation/argo/external-dns/values.yaml
+    - repoURL: https://github.com/bacchus-snu/cd-manifests.git
+      targetRevision: feat/talos
+      ref: values

--- a/foundation/argo/external-dns/resources.yaml
+++ b/foundation/argo/external-dns/resources.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  namespace: external-dns
+  name: default
+spec:
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    role: vault-secrets-operator
+    serviceAccount: default
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  namespace: external-dns
+  name: cloudflare
+spec:
+  vaultAuthRef: default
+  type: kv-v2
+  mount: secret
+  path: external-dns/cloudflare/secret
+  destination:
+    create: true
+    name: cloudflare

--- a/foundation/argo/external-dns/values.yaml
+++ b/foundation/argo/external-dns/values.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: v0.14.0
+
 provider: cloudflare
 
 env:

--- a/foundation/argo/external-dns/values.yaml
+++ b/foundation/argo/external-dns/values.yaml
@@ -1,0 +1,18 @@
+provider: cloudflare
+
+env:
+  - name: CF_API_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: cloudflare
+        key: CF_API_TOKEN
+
+sources:
+  - gateway-httproute
+  
+domainFilters:
+  - snucse.org
+  - bacchus.io
+
+txtOwnerId: waiter
+policy: sync

--- a/foundation/argo/external-dns/values.yaml
+++ b/foundation/argo/external-dns/values.yaml
@@ -9,7 +9,7 @@ env:
 
 sources:
   - gateway-httproute
-  
+
 domainFilters:
   - snucse.org
   - bacchus.io


### PR DESCRIPTION
ExternalDNS 배포 (그런데 Ingress 대신 HttpRoute를 곁들인)

### Changes
* ExternalDNS Argo 앱 추가
  * `v0.14.0` 이미지 사용 (gateway 에 target overriding annotation 지원) 
  * `gateway-httproute` 를 소스로 설정
  * `--txt-owner-id` 추가
  * policy는 없어진 레코드 구질구질하게 남아있는 거 싫어하므로 sync로 설정하였습니다
* Cloudflare API token을 Vault에 추가
  * cert-manager랑 같은 거 쓰고 있어요
  * 클플 홈페이지에서 API 토큰 설명 바꿔야할 듯?
* gateway에 target annotation 추가하여 `waiter.bacchus.io` cname 걸도록 강제