### PR TITLE
Revert waiter cilium version to 1.15.6

### DIFF
--- a/argocd/waiter/cilium/app.yaml
+++ b/argocd/waiter/cilium/app.yaml
@@ -38,7 +38,7 @@ spec:
         - /data
   sources:
     - repoURL: https://helm.cilium.io/
-      targetRevision: 1.16.0
+      targetRevision: 1.15.6
       chart: cilium
       helm:
         valueFiles:


### PR DESCRIPTION
### Description
현재 waiter cluster의 cilium 버전을 1.16.0으로 argocd를 통해 update 후 cluster 외부 접근 관련 이슈가 발생하여 수동으로 1.15.6 버전으로 내려 서버 사이드 (1.15.6) <> argocd (1.16.0) 의 sync 가 맞지 않습니다. 이에 manifest 또한 버전을 변경합니다. 

- cilium pod 이미지 버전 
![image](https://github.com/user-attachments/assets/e3a6e367-8e6c-49ae-b5e6-85b0126abbcf)
