### PR TITLE
sgs harbor: set registry.relativeurls=true

### DIFF
--- a/argocd/waiter/bacchus-sgs-registry/values.yaml
+++ b/argocd/waiter/bacchus-sgs-registry/values.yaml
@@ -23,6 +23,7 @@ core:
 jobservice:
   existingSecret: bacchus-sgs-registry-harbor-secrets
 registry:
+  relativeurls: true
   existingSecret: bacchus-sgs-registry-harbor-secrets
   credentials:
     existingSecret: bacchus-sgs-registry-harbor-secrets


### PR DESCRIPTION
`registry.relativeurls` (default: false)

Description: If true, the registry returns relative URLs in Location headers. The client is responsible for resolving the correct URL. Needed if harbor is behind a reverse proxy.