### PR TITLE
Revert "chore(deps): update registry-1.docker.io/bitnamicharts/postgresql docker tag to v16"

### DIFF
--- a/argocd/waiter/bacchus-sgs/app.yaml
+++ b/argocd/waiter/bacchus-sgs/app.yaml
@@ -20,7 +20,7 @@ spec:
       path: argocd/waiter/bacchus-sgs
       kustomize: {}
     - repoURL: registry-1.docker.io/bitnamicharts
-      targetRevision: 16.0.1
+      targetRevision: 15.5.32
       chart: postgresql
       helm:
         valueFiles:

--- a/argocd/waiter/id-dev/app.yaml
+++ b/argocd/waiter/id-dev/app.yaml
@@ -29,7 +29,7 @@ spec:
         valueFiles:
           - $values/argocd/waiter/id-dev/redis-values.yaml
     - repoURL: registry-1.docker.io/bitnamicharts
-      targetRevision: 16.0.1
+      targetRevision: 15.5.32
       chart: postgresql
       helm:
         valueFiles:

--- a/argocd/waiter/id/app.yaml
+++ b/argocd/waiter/id/app.yaml
@@ -29,7 +29,7 @@ spec:
         valueFiles:
           - $values/argocd/waiter/id/redis-values.yaml
     - repoURL: registry-1.docker.io/bitnamicharts
-      targetRevision: 16.0.1
+      targetRevision: 15.5.32
       chart: postgresql
       helm:
         valueFiles:


### PR DESCRIPTION
Reverts bacchus-snu/cd-manifests#429

Requires manual intervention due to 16 -> 17 upgrade