### PR TITLE
feat(vpn): mss clamping and move image version to kustomize

### DIFF
--- a/argocd/waiter/bacchus-vpn/kustomization.yaml
+++ b/argocd/waiter/bacchus-vpn/kustomization.yaml
@@ -12,6 +12,11 @@ labels:
     includeSelectors: true
 
 images:
+  - name: busybox
+    newTag: '1.37'
+  - name: kubectl
+    newName: bitnami/kubectl
+    newTag: '1.30'
   - name: wg-access-server
     newName: ghcr.io/freifunkmuc/wg-access-server
     newTag: v0.12.1

--- a/argocd/waiter/bacchus-vpn/statefulset.yaml
+++ b/argocd/waiter/bacchus-vpn/statefulset.yaml
@@ -16,16 +16,20 @@ spec:
   template:
     spec:
       initContainers:
-        - name: sysctl-forward
-          image: busybox:1.36
+        - name: network-setup
+          image: busybox # replaced by kustomize
           command:
             - sh
             - -c
-            - sysctl -w net.ipv4.ip_forward=1
+            - |
+                # enable ip forwarding
+                sysctl -w net.ipv4.ip_forward=1
+                # clamp MSS to PMTU
+                iptables -A iptables -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
           securityContext:
             privileged: true
         - name: envoy-patch
-          image: bitnami/kubectl:latest
+          image: kubectl
           restartPolicy: Always # sidecar
           securityContext:
             allowPrivilegeEscalation: false

--- a/argocd/waiter/lab-vpn/deployment.yaml
+++ b/argocd/waiter/lab-vpn/deployment.yaml
@@ -23,12 +23,16 @@ spec:
           command:
             - sh
             - -c
-            - sysctl -w net.ipv4.ip_forward=1
+            - |
+                # enable ip forwarding
+                sysctl -w net.ipv4.ip_forward=1
+                # clamp MSS to PMTU
+                iptables -A iptables -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
           securityContext:
             privileged: true
       containers:
         - name: app
-          image: ghcr.io/bacchus-snu/lab-vpn:master@sha256:38876c845d270b2c3d1957db122f4647ebb8f77de48bccf4902372f78014e99f
+          image: lab-vpn
           command:
             - sh
             - -c

--- a/argocd/waiter/lab-vpn/kustomization.yaml
+++ b/argocd/waiter/lab-vpn/kustomization.yaml
@@ -2,3 +2,10 @@ resources:
   - deployment.yaml
   - service.yaml
   - secret.yaml
+
+images:
+  - name: busybox
+    newTag: '1.37'
+  - name: lab-vpn
+    newName: ghcr.io/bacchus-snu/lab-vpn
+    digest: sha256:38876c845d270b2c3d1957db122f4647ebb8f77de48bccf4902372f78014e99f


### PR DESCRIPTION
- VPN의 경우 wireguard를 사용해서 MTU 관련 이슈가 있을 수 있습니다. MSS clamping으로 해결합니다.
- 이미지 버전을 kustomization으로 옮기면 renovate로 관리하기 편해집니다.