### PR TITLE
Revert "chore(deps): update ghcr.io/freifunkmuc/wg-access-server docker tag to v0.13.0"

### DIFF
--- a/argocd/waiter/bacchus-vpn/kustomization.yaml
+++ b/argocd/waiter/bacchus-vpn/kustomization.yaml
@@ -19,4 +19,4 @@ images:
     newTag: '1.31'
   - name: wg-access-server
     newName: ghcr.io/freifunkmuc/wg-access-server
-    newTag: v0.13.0
+    newTag: v0.12.1


### PR DESCRIPTION
Reverts bacchus-snu/cd-manifests#480

이유는 아직 모르지만 안됨