### PR TITLE
feat(bacchus-sgs-registry): pvc size 0.5 -> 1TiB

### DIFF
--- a/argocd/waiter/bacchus-sgs-registry/values.yaml
+++ b/argocd/waiter/bacchus-sgs-registry/values.yaml
@@ -11,7 +11,7 @@ externalURL: https://sgs-registry.snucse.org
 persistence:
   persistentVolumeClaim:
     registry:
-      size: 500Gi
+      size: 1024Gi
 
 # otherwise, deployment hangs due to multi-attach error
 updateStrategy:


### PR DESCRIPTION
See [pvc dashboard (private)](https://dashboard.internal.bacchus.io/d/919b92a8e8041bd567af9edab12c840c/kubernetes-persistent-volumes?var-namespace=bacchus-sgs-registry&var-volume=bacchus-sgs-registry-harbor-registry).
Bartender쪽 저장공간은 `6.43 TiB of 10.92 TiB` 라서 아직은 여유가 있습니다.